### PR TITLE
remove gevent dependency via callbacks

### DIFF
--- a/plaid/client.py
+++ b/plaid/client.py
@@ -55,7 +55,7 @@ class Client(object):
         'upgrade_step': '/upgrade/step'
     }
 
-    def __init__(self, client_id, secret, access_token=None, http_request=_http_request):
+    def __init__(self, client_id, secret, access_token=None, http_request=_http_request, delay_webhook=None):
         """
         `client_id`     str     Your Plaid client ID
         `secret`        str     Your Plaid secret

--- a/plaid/client.py
+++ b/plaid/client.py
@@ -55,7 +55,7 @@ class Client(object):
         'upgrade_step': '/upgrade/step'
     }
 
-    def __init__(self, client_id, secret, access_token=None, http_request=_http_request, delay_webhook=None):
+    def __init__(self, client_id, secret, access_token=None, http_request=_http_request):
         """
         `client_id`     str     Your Plaid client ID
         `secret`        str     Your Plaid secret

--- a/plaid/sandbox/client.py
+++ b/plaid/sandbox/client.py
@@ -35,11 +35,11 @@ class SandboxClient(Client):
 
     @staticmethod
     def post_initial_webhook(url, data):
-        assert False, 'must override post_initial_webhook staticmethod'
+        raise NotImplementedError
 
     @staticmethod
     def post_historical_webhook(url, data):
-        assert False, 'must override post_historical_webhook staticmethod'
+        raise NotImplementedError
 
     @staticmethod
     def _load_fixture(filename):


### PR DESCRIPTION
@jedipi @mannygit is this what you had in mind?

Since the unity service configuration code is agnostic to which client is being used, I needed to add a `delay_webhook` callback parameter to both clients. I'm not super happy about that, so if you have something nicer in mind, please let me know.
