### PR TITLE
upgrade_step should take upgrade_to parameter

### DIFF
--- a/plaid/__init__.py
+++ b/plaid/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.2.10-affirm'
+__version__ = '0.2.11-affirm'
 
 from client import Client, require_access_token

--- a/plaid/client.py
+++ b/plaid/client.py
@@ -282,11 +282,13 @@ class Client(object):
         return self.http_request(url, 'POST', data)
 
     @require_access_token
-    def upgrade_step(self, mfa):
+    def upgrade_step(self, upgrade_to, mfa):
         """
         Perform a MFA (Multi Factor Authentication) step, requires
         `access_token`
 
+        `upgrade_to`    str     The service to upgrade to; must match `upgrade`
+                                call.
         `mfa`           str     The MFA answer, e.g. an answer to q security
                                 question or code sent to your phone, etc.
         """
@@ -296,6 +298,7 @@ class Client(object):
             'client_id': self.client_id,
             'secret': self.secret,
             'access_token': self.access_token,
+            'upgrade_to': upgrade_to,
             'mfa': mfa
         }
 

--- a/plaid/sandbox/client.py
+++ b/plaid/sandbox/client.py
@@ -189,7 +189,8 @@ class SandboxClient(Client):
             self._process_connect_success(data)
         return MockResponse(data, status_code)
 
-    def upgrade_step(self, mfa, options=None):
+    def upgrade_step(self, upgrade_to, mfa, options=None):
+        assert upgrade_to == 'auth'
         account = self.get_account()
         institution = self._institutions[account['account_type']]
 


### PR DESCRIPTION
This is not documented by Plaid, but logs show that the `/upgrade/step` endpoint requires the `upgrade_to` parameter.
